### PR TITLE
UCC: Change package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_book
 docs/api.md
 dist/
 .DS_Store
+~/.npm

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@DedalusDIIT/cornerstone-core",
+  "name": "@dedalusdiit/cornerstone-core",
   "version": "2.2.9",
   "description": "HTML5 Medical Image Viewer Component",
   "main": "./dist/cornerstone.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-core",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "HTML5 Medical Image Viewer Component",
   "main": "./dist/cornerstone.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "module": "./dist/cornerstone.js",
   "publishConfig": {
+    "cache": "~/.npm",
     "registry": "https://npm.pkg.github.com/"
   },
   "repository": {

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '2.2.8';
+export default '2.2.10';


### PR DESCRIPTION
# What does this Merge Request do?

Updates package name as npm version 7 and it's new package-lock format seem to have issues with capitalization in package versions.

Also, the property 'cache' is added to `publishConfig` in the package.json as otherwise `npm publish` fails with the newest npm version. (https://github.com/npm/cli/issues/2834)

Package with version 2.2.10. is published to reflect these changes.
<!-- Give a brief summary (1-2 sentences) what this Merge Request is about. -->