### PR TITLE
DVISA-3183: Request DICOM image object when needed for measuremets in JPEG mode 

### DIFF
--- a/src/getPixels.js
+++ b/src/getPixels.js
@@ -1,6 +1,7 @@
 import { getEnabledElement } from './enabledElements.js';
 import getStoredPixels from './getStoredPixels.js';
 import getModalityLUT from './internal/getModalityLUT.js';
+import { default as imageCache } from './imageCache.js';
 
 /**
  * Retrieves an array of pixels from a rectangular region with modality LUT transformation applied
@@ -12,10 +13,43 @@ import getModalityLUT from './internal/getModalityLUT.js';
  * @param {Number} height The height of the of the sampling rectangle in image coordinates
  * @returns {Array} The modality pixel value of the pixels in the sampling rectangle
  */
-export default function (element, x, y, width, height) {
-  const storedPixels = getStoredPixels(element, x, y, width, height);
+export default function (element, x, y, width, height, options = { hqImageId: undefined }) {
+  const storedPixels = getStoredPixels(element, x, y, width, height, options);
   const ee = getEnabledElement(element);
-  const mlutfn = getModalityLUT(ee.image.slope, ee.image.intercept, ee.viewport.modalityLUT);
+
+  const { slope, intercept } = getSlopeAndIntercept(ee, options.hqImageId);
+
+  const mlutfn = getModalityLUT(slope, intercept, ee.viewport.modalityLUT);
 
   return storedPixels.map(mlutfn);
+}
+
+
+/**
+ * Determines the slope and intercept values to use for modality LUT.
+ * If `hqImageId` is provided and a corresponding image is found loaded
+ * in the Cornerstone cache, returns its slope and intercept. Otherwise,
+ * falls back to the current enabled element's image values.
+ *
+ * @param {Object} enabledElement - Cornerstone enabled element with the current image.
+ * @param {String} [hqImageId] - Optional high-quality image ID to prefer for pixel data when available.
+ * @returns {{ slope: number, intercept: number }} Selected slope and intercept for LUT.
+ */
+function getSlopeAndIntercept (enabledElement, hqImageId) {
+  let { slope, intercept } = enabledElement.image;
+
+  if (hqImageId !== undefined) {
+    const foundHQImage = imageCache.imageCache[hqImageId];
+
+    if (foundHQImage && foundHQImage.loaded) {
+      slope = foundHQImage.image.slope;
+      intercept = foundHQImage.image.intercept;
+    }
+  }
+
+  return {
+    slope,
+    intercept
+  };
+
 }

--- a/src/getStoredPixels.js
+++ b/src/getStoredPixels.js
@@ -1,4 +1,5 @@
 import { getEnabledElement } from './enabledElements.js';
+import { default as imageCache } from './imageCache.js';
 
 /**
  * Retrieves an array of stored pixel values from a rectangular region of an image
@@ -8,19 +9,24 @@ import { getEnabledElement } from './enabledElements.js';
  * @param {Number} y The y coordinate of the top left corner of the sampling rectangle in image coordinates
  * @param {Number} width The width of the of the sampling rectangle in image coordinates
  * @param {Number} height The height of the of the sampling rectangle in image coordinates
+ * @param {Object} options Optional parameters
+ * @param {String} options.hqImageId Optional high quality image ID to use for pixel data
  * @returns {Array} The stored pixel value of the pixels in the sampling rectangle
  */
-export default function (element, x, y, width, height) {
+export default function (element, x, y, width, height, options = { hqImageId: undefined }) {
   if (element === undefined) {
     throw new Error('getStoredPixels: parameter element must not be undefined');
   }
 
   x = Math.round(x);
   y = Math.round(y);
+
   const enabledElement = getEnabledElement(element);
+
+  const pixelData = getPixelData(enabledElement, options.hqImageId);
+
   const storedPixels = [];
   let index = 0;
-  const pixelData = enabledElement.image.getPixelData();
 
   for (let row = 0; row < height; row++) {
     for (let column = 0; column < width; column++) {
@@ -31,4 +37,28 @@ export default function (element, x, y, width, height) {
   }
 
   return storedPixels;
+}
+
+/**
+ * Selects the pixel data source for sampling.
+ * If a valid high-quality image ID is provided and the image is found and loaded 
+ * in the Cornerstone cache, the function returns its pixel data.
+ * Otherwise, it falls back to the current enabled element's image pixel data.
+ *
+ * @param {Object} enabledElement - Cornerstone enabled element with the current image.
+ * @param {String} [hqImageId] - Optional high-quality image ID to prefer for pixel data when available.
+ * @returns {Array} Pixel data to use for sampling operations.
+ */
+function getPixelData (enabledElement, hqImageId) {
+  let pixelData = enabledElement.image.getPixelData();
+
+  if (hqImageId !== undefined) {
+    const foundHQImage = imageCache.imageCache[hqImageId];
+
+    if (foundHQImage && foundHQImage.loaded) {
+      pixelData = foundHQImage.image.getPixelData();
+    }
+  }
+
+  return pixelData;
 }

--- a/test/getStoredPixels_test.js
+++ b/test/getStoredPixels_test.js
@@ -4,6 +4,7 @@ import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';
 import getStoredPixels from '../src/getStoredPixels.js';
 import disable from '../src/disable.js';
+import { default as imageCache } from '../src/imageCache.js';
 
 describe('getStoredPixels', function () {
   beforeEach(function () {
@@ -56,6 +57,66 @@ describe('getStoredPixels', function () {
 
   it('should throw an error if the element is undefined', function () {
     assert.throws(() => getStoredPixels(undefined, 0, 0, 1, 1));
+  });
+
+  it('should use HQ image pixel data when available', function () {
+    // Arrange
+    const element = this.element;
+
+    // HQ image setup in cache
+    const hqImageId = 'hq-exampleImageId';
+    const hqGetPixelData = () => new Uint8Array([10, 11, 12, 13, 14, 15, 16, 17, 18]);
+    imageCache.imageCache[hqImageId] = {
+      image: {
+        getPixelData: hqGetPixelData
+      },
+      loaded: true
+    };
+
+    // Act
+    const storedPixelsHQ1 = getStoredPixels(element, 1, 1, 2, 2, { hqImageId });
+    const storedPixelsHQ2 = getStoredPixels(element, 0, 0, 1, 1, { hqImageId });
+    const storedPixelsHQ3 = getStoredPixels(element, 0, 1, 2, 2, { hqImageId });
+
+    // Assert (using HQ pixel data)
+    // From HQ pixelData:
+    // 10 11 12
+    // 13 14 15
+    // 16 17 18
+    assert.deepEqual(storedPixelsHQ1, [14, 15, 17, 18]);
+    assert.deepEqual(storedPixelsHQ2, [10]);
+    assert.deepEqual(storedPixelsHQ3, [13, 14, 16, 17]);
+
+    // Cleanup HQ image from cache
+    delete imageCache.imageCache[hqImageId];
+  });
+
+  it('should fall back when HQ image is cached but not loaded', function () {
+    // Arrange
+    const element = this.element;
+
+    // HQ image present in cache but not loaded
+    const hqImageId = 'hq-exampleImageId-not-loaded';
+    const hqGetPixelData = () => new Uint8Array([100, 101, 102, 103, 104, 105, 106, 107, 108]);
+    imageCache.imageCache[hqImageId] = {
+      image: {
+        getPixelData: hqGetPixelData
+      },
+      loaded: false
+    };
+
+    // Act: should use the base image pixel data, not HQ
+    const storedPixels1 = getStoredPixels(element, 1, 1, 2, 2, { hqImageId });
+    const storedPixels2 = getStoredPixels(element, 0, 0, 1, 1, { hqImageId });
+    const storedPixels3 = getStoredPixels(element, 0, 1, 2, 2, { hqImageId });
+
+    // Assert: values match base image [1..9]
+    assert.deepEqual(storedPixels1, [5, 6, 8, 9]);
+    assert.deepEqual(storedPixels2, [1]);
+    assert.deepEqual(storedPixels3, [4, 5, 7, 8]);
+
+    // Cleanup
+    delete imageCache.imageCache[hqImageId];
   });
 
   afterEach(function () {


### PR DESCRIPTION
This pull request adds support for using high-quality (HQ) images from the Cornerstone image cache when retrieving pixel data and applying modality LUT transformations. If an HQ image is available and loaded in the cache, both its pixel data and slope/intercept values are used for computations; otherwise, the system falls back to the currently displayed image. This is later needed for the implementation of [DVISA-3183](https://jira.dedalus.com/browse/DVISA-3183) and [DVISA-2660](https://jira.dedalus.com/browse/DVISA-2660) where we want to support pixel values also in JPEG mode.

### Feature: High-Quality Image Support

* Updated `getPixels` and `getStoredPixels` to accept an optional `hqImageId` parameter. When provided, these functions check the image cache for a loaded HQ image and use its pixel data and slope/intercept for LUT calculations; otherwise, they use the base image. (`src/getPixels.js`, `src/getStoredPixels.js`) [[1]](diffhunk://#diff-7ef73b7cf4b7481b10ee097e98f6f842091075b9556bc9d028aeb7a056d77c09L15-R55) [[2]](diffhunk://#diff-cb1bfe019fcd3b246b0c7b0ba4a660486f377e8dc75b41b85e8c5eeed6baca4eR12-L23)
* Added helper functions `getSlopeAndIntercept` and `getPixelData` to encapsulate logic for selecting the correct image and its properties based on cache availability and loading status. (`src/getPixels.js`, `src/getStoredPixels.js`) [[1]](diffhunk://#diff-7ef73b7cf4b7481b10ee097e98f6f842091075b9556bc9d028aeb7a056d77c09L15-R55) [[2]](diffhunk://#diff-cb1bfe019fcd3b246b0c7b0ba4a660486f377e8dc75b41b85e8c5eeed6baca4eR41-R64)
